### PR TITLE
Reverted handler back to task

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,2 @@
 ---
-- name: comple glib schemas
-  become: yes
-  command: "/usr/bin/glib-compile-schemas {{ gnome_proxy_glib_schemas_directory }}"
+# handlers file for ansible-role-gnome-proxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,5 +14,9 @@
     owner: root
     group: root
     mode: 'u=rw,go=r'
-  notify:
-    - comple glib schemas
+  register: gnome_proxy_config
+
+- name: apply glib schemas changes
+  become: yes
+  command: "/usr/bin/glib-compile-schemas {{ gnome_proxy_glib_schemas_directory }}"
+  when: gnome_proxy_config.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,11 @@
   register: gnome_proxy_config
 
 - name: apply glib schemas changes
+  tags:
+    # Suppress warning: [ANSIBLE0016] Tasks that run when changed should likely be handlers
+    # Since the command is invoked with an argument that is role specific it
+    # doesn't make sense to use a handler, which are global to the playbook.
+    - skip_ansible_lint
   become: yes
   command: "/usr/bin/glib-compile-schemas {{ gnome_proxy_glib_schemas_directory }}"
   when: gnome_proxy_config.changed


### PR DESCRIPTION
Since handlers are global they aren't a good fit for commands that have a role specific argument.