### PR TITLE
Switched to single quotes for YAML strings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   become: yes
   template:
     src: proxy.gschema.override.j2
-    dest: "{{ gnome_proxy_glib_schemas_directory }}/{{ gnome_proxy_overide_filename }}"
+    dest: '{{ gnome_proxy_glib_schemas_directory }}/{{ gnome_proxy_overide_filename }}'
     owner: root
     group: root
     mode: 'u=rw,go=r'
@@ -23,5 +23,5 @@
     # doesn't make sense to use a handler, which are global to the playbook.
     - skip_ansible_lint
   become: yes
-  command: "/usr/bin/glib-compile-schemas {{ gnome_proxy_glib_schemas_directory }}"
+  command: '/usr/bin/glib-compile-schemas {{ gnome_proxy_glib_schemas_directory }}'
   when: gnome_proxy_config.changed


### PR DESCRIPTION
Switched to single quotes (rather than double quotes) for YAML strings where escaping isn't required.