### PR TITLE
Dropped support for Ubuntu Trusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Requirements
 
         * Ubuntu
 
-            * Trusty (14.04)
             * Xenial (16.04)
             * Bionic (18.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
         - bionic
   galaxy_tags:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-gnome-proxy-ubuntu-min
-    image: ubuntu:14.04
+    image: ubuntu:16.04
   - name: ansible-role-gnome-proxy-ubuntu-max
     image: ubuntu:18.04
 


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Trusty (14.04).