### PR TITLE
Increased minimum Ansible version to 2.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         ansible-version:
-          - '2.8.16'
+          - '2.9.26' # min-ansible-test-version
           - '2.10.7' # max-ansible-test-version
 
     env:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ browser).
 Requirements
 ------------
 
-* Ansible >= 2.8
+* Ansible >= 2.9
 
     * Note: earlier versions of Ansible are likely to work but have not been
       tested.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     Role for configuring the proxy settings for Gnome applications.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.8
+  min_ansible_version: 2.9
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Ansible no longer supports version 2.8.